### PR TITLE
✨ (ios/CodePush): integrate RCTReloadCommand for improved reload handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ Examples/testapp_rn
 
 # Android debug build files (conflict ignoring #Visual Studio files)
 !android/app/src/debug/
+
+**/*.tgz

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -5,6 +5,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
+#import <React/RCTReloadCommand.h>
 #else // back compatibility for RN version < 0.40
 #import "RCTAssert.h"
 #import "RCTBridgeModule.h"
@@ -31,7 +32,7 @@
     long long _latestExpectedContentLength;
     long long _latestReceivedConentLength;
     BOOL _didUpdateProgress;
-    
+
     BOOL _allowed;
     BOOL _restartInProgress;
     NSMutableArray *_restartQueue;
@@ -376,7 +377,7 @@ static NSString *const LatestRollbackCountKey = @"count";
     _allowed = YES;
     _restartInProgress = NO;
     _restartQueue = [NSMutableArray arrayWithCapacity:1];
-    
+
     self = [super init];
     if (self) {
         [self initializeUpdateAfterRestart];
@@ -540,7 +541,7 @@ static NSString *const LatestRollbackCountKey = @"count";
             [super.bridge setValue:[CodePush bundleURL] forKey:@"bundleURL"];
         }
 
-        [super.bridge reload];
+        RCTTriggerReloadCommandListeners(@"react-native-code-push: Restart");
     });
 }
 


### PR DESCRIPTION
Add the RCTReloadCommand import to utilize the new reload mechanism in React Native. This change replaces the direct call to `[super.bridge reload]` with `RCTTriggerReloadCommandListeners`, providing a more robust and flexible way to handle reloads. This update aligns with the latest React Native practices, ensuring better compatibility and potentially reducing issues related to manual reloads.